### PR TITLE
add telephone-line-workgroups2-segment

### DIFF
--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -96,5 +96,9 @@ mouse-3: Toggle minor modes"
            (seq-take tag 2)
          tag))))
 
+(eval-after-load 'workgroups2
+  '(telephone-line-defsegment telephone-line-workgroups2-segment
+     (wg-mode-line-string)))
+
 (provide 'telephone-line-segments)
 ;;; telephone-line-segments.el ends here


### PR DESCRIPTION
The new segment can be used to display workgroups information from [workgroups2](https://github.com/pashinin/workgroups2)

Fixes #23

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dbordak/telephone-line/24)
<!-- Reviewable:end -->
