### PR TITLE
Added segments for window number and projectile.

### DIFF
--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -98,9 +98,11 @@ mouse-3: Toggle minor modes"
   (when (boundp 'erc-modified-channels-object)
     (string-trim erc-modified-channels-object)))
 
-(telephone-line-defsegment telephone-line-window-number-segment ()
+(telephone-line-defsegment telephone-line-window-number-segment (&optional in-unicode)
   (when (bound-and-true-p winum-mode)
-    (winum-get-number-string)))
+    (if in-unicode
+        (propertize (format "%c" (+ 9311 (winum-get-number))) 'face `winum-face)
+      (winum-get-number-string))))
 
 (telephone-line-defsegment telephone-line-projectile-segment ()
     (if (and (fboundp 'projectile-project-name)

--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -98,6 +98,23 @@ mouse-3: Toggle minor modes"
   (when (boundp 'erc-modified-channels-object)
     (string-trim erc-modified-channels-object)))
 
+(telephone-line-defsegment telephone-line-window-number-segment ()
+  (when (bound-and-true-p winum-mode)
+    (winum-get-number-string)))
+
+(telephone-line-defsegment telephone-line-projectile-segment ()
+    (if (and (fboundp 'projectile-project-name)
+             (projectile-project-name))
+        (propertize (format "[%s]" (concat (projectile-project-name)))
+                    'face '(:inherit)
+                    'display '(raise 0.0)
+                    'help-echo "Switch project"
+                    'mouse-face '(:box 1)
+                    'local-map (make-mode-line-mouse-map
+                                'mouse-1 (lambda ()
+                                           (interactive)
+                                           (projectile-switch-project))))))
+  
 (eval-after-load 'evil
   '(telephone-line-defsegment* telephone-line-evil-tag-segment ()
      (let ((tag (cond


### PR DESCRIPTION
This PR adds two simple segments, one to show the window number while using `winum-mode` and the other to show a clickable projectile project name.