### PR TITLE
Use built-in faces in flycheck-segment.

### DIFF
--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -241,14 +241,14 @@ Inspired by doom-modeline."
                                     (if (or .error .warning)
                                         (propertize (format "Problems: %s/%s"
                                                             (or .error 0) (or .warning 0))
-                                                    'face '(:foreground "orange"))
+                                                    'face 'warning))
                                       ""))
                                 (propertize ":)" 'face 'telephone-line-unimportant)))
                    ('running     "*")
                    ('no-checker  (propertize "-" 'face 'telephone-line-unimportant))
                    ('not-checked "=")
-                   ('errored     (propertize "!" 'face '(:foreground "tomato")))
-                   ('interrupted (propertize "." 'face '(:foreground "tomato")))
+                   ('errored     (propertize "!" 'face 'error))
+                   ('interrupted (propertize "." 'face 'error))
                    ('suspicious  "?"))))
       (propertize text
                   'help-echo (pcase flycheck-last-status-change

--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -241,14 +241,14 @@ Inspired by doom-modeline."
                                     (if (or .error .warning)
                                         (propertize (format "Problems: %s/%s"
                                                             (or .error 0) (or .warning 0))
-                                                    'face 'warning))
+                                                    'face 'telephone-line-warning)
                                       ""))
                                 (propertize ":)" 'face 'telephone-line-unimportant)))
                    ('running     "*")
                    ('no-checker  (propertize "-" 'face 'telephone-line-unimportant))
                    ('not-checked "=")
-                   ('errored     (propertize "!" 'face 'error))
-                   ('interrupted (propertize "." 'face 'error))
+                   ('errored     (propertize "!" 'face 'telephone-line-error))
+                   ('interrupted (propertize "." 'face 'telephone-line-error))
                    ('suspicious  "?"))))
       (propertize text
                   'help-echo (pcase flycheck-last-status-change

--- a/telephone-line.el
+++ b/telephone-line.el
@@ -67,7 +67,7 @@
 
 (defface telephone-line-warning
   '((t (:inherit warning :underline nil :strike-through nil)))
-  "Face to higlight errors in telephone-line."
+  "Face to higlight warnings in telephone-line."
   :group 'telephone-line)
 
 (defface telephone-line-evil

--- a/telephone-line.el
+++ b/telephone-line.el
@@ -60,6 +60,16 @@
   "Hightlight face for the projectile segment"
   :group 'telephone-line)
 
+(defface telephone-line-error
+  '((t (:inherit warning :underline nil :strike-through nil)))
+  "Face to higlight errors in telephone-line. "
+  :group 'telephone-line)
+
+(defface telephone-line-warning
+  '((t (:inherit warning :underline nil :strike-through nil)))
+  "Face to higlight errors in telephone-line."
+  :group 'telephone-line)
+
 (defface telephone-line-evil
   '((t (:foreground "white" :weight bold :inherit mode-line)))
   "Meta-face used for property inheritance on all telephone-line-evil faces."

--- a/telephone-line.el
+++ b/telephone-line.el
@@ -61,7 +61,7 @@
   :group 'telephone-line)
 
 (defface telephone-line-error
-  '((t (:inherit warning :underline nil :strike-through nil)))
+  '((t (:inherit error :underline nil :strike-through nil)))
   "Face to higlight errors in telephone-line. "
   :group 'telephone-line)
 


### PR DESCRIPTION
To let the user custom themes simple override those colors, because Emacs built-in colors don't fit nice into non-default Emacs themes.