### PR TITLE
Little fix for projectile-buffer-segment.

### DIFF
--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -206,8 +206,8 @@ TRUNCATE-UNTIL sets when to stop truncating; -1 for all but one (i.e. filename),
 If SHOW-PROJECT-PATH is non-nil, shows the abbreviated path leading up to the project dir. Value works the same as TRUNCATE-UNTIL
 Inspired by doom-modeline."
   (if (and (buffer-file-name)
-           (fboundp 'projectile-project-root)
-           (fboundp 'projectile-project-name))
+           (bound-and-true-p projectile-project-root)
+           (bound-and-true-p projectile-project-name))
       (list ""
             (if show-project-path
                 (propertize


### PR DESCRIPTION
Currently telephone-line-projectile-buffer-segment doesn't display a buffer name outside of project. 
```
Error during redisplay: (eval (telephone-line-add-subseparators ...)
signaled (error "You’re not in a project") [4 times]
```