### PR TITLE
Fix projectile-buffer-segment to display root.

### DIFF
--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -205,9 +205,10 @@ If it doesn't exist, create and cache it."
 TRUNCATE-UNTIL sets when to stop truncating; -1 for all but one (i.e. filename), 0 for everything, etc.
 If SHOW-PROJECT-PATH is non-nil, shows the abbreviated path leading up to the project dir. Value works the same as TRUNCATE-UNTIL
 Inspired by doom-modeline."
-  (if (and (buffer-file-name)
-           (bound-and-true-p projectile-project-root)
-           (bound-and-true-p projectile-project-name))
+  (if (and (bound-and-true-p projectile-mode)
+           (buffer-file-name)
+           (projectile-project-root)
+           (projectile-project-name))
       (list ""
             (if show-project-path
                 (propertize


### PR DESCRIPTION
Doh, today I've found that after my #81 projectile-buffer-segment doesn't display a project root, but it now works outside of a project. I though that the `projectile-project-root` function write a value into the `projectile-project-root` variable, but it's incorrect.

As far as I can understand this part of projectile.
```emacs-lisp
(defvar-local projectile-project-root nil
  "Defines a custom Projectile project root.
This is intended to be used as a file local variable.")
```
The `projectile-project-root variable` will have nil value until a user specifies it manually, so projectile-buffer-segment fails to display a project root. Also, in the first place, the segment checks if projectile-mode is defined.

Finally it should work as expected. :clap: