### PR TITLE
Two small segments - buffer name and modified state

### DIFF
--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -92,6 +92,14 @@ Adapted from doom-modeline."
 (telephone-line-defsegment* telephone-line-minions-mode-segment ()
   (telephone-line-raw minions-mode-line-modes t))
 
+(telephone-line-defsegment* telephone-line-buffer-name-segment ()
+  (telephone-line-raw (buffer-name)))
+
+(telephone-line-defsegment* telephone-line-buffer-modified-segment ()
+    (if (buffer-modified-p)
+        (telephone-line-raw "!")
+      (telephone-line-raw "-")))
+
 (telephone-line-defsegment telephone-line-narrow-segment ()
   "%n")
 


### PR DESCRIPTION
Out of the usual buffer indicator I care the most about these two only, and rarely about encoding, line endings, etc.

I also thought of having buffer modified one changing colors? Or showing an icon like spaceline + spaceline-all-the-icons did, but didn't get as far.
Actually, I had an implementation that took &optional parameters for the characters and couldn't get it working.

But before spending more time on it, I wanted to know if you saw any value in these. They are simple enough that anyone could come up with their own two-liner implementation.
Maybe if the modified indicator switched colors, it would give more value.

Thoughts?