### PR TITLE
customizable strings and faces for buffer-modified-segment

### DIFF
--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -95,10 +95,40 @@ Adapted from doom-modeline."
 (telephone-line-defsegment* telephone-line-buffer-name-segment ()
   (telephone-line-raw (buffer-name)))
 
-(telephone-line-defsegment* telephone-line-buffer-modified-segment ()
-    (if (buffer-modified-p)
-        (telephone-line-raw "!")
-      (telephone-line-raw "-")))
+(defface telephone-line-buffer-modified '((t (:foreground "red")))
+  "Show the telephone-line-buffer-modified-display-string in this face when the buffer has been modified
+
+    Modified means 'changed in memory since it was last saved to disk'
+    Remember that you need to set a nil face-pair in your config for this to work, like so:
+    (setq telephone-line-lhs
+    	'( (nil . telephone-line-buffer-modified-segment) ) )"
+  :group 'telephone-line )
+
+(defcustom telephone-line-buffer-modified-display-string "!"
+  "text to display when the buffer has been modified since the last time the buffer was saved to disk"
+  :type '(string)
+  :group 'telephone-line)
+
+(defface telephone-line-buffer-unmodified '((t (:foreground "SlateGray2")))
+  "Show the telephone-line-buffer-unmodified-display-string in this face when the buffer has not been modified
+
+    Modified means 'changed in memory since it was last saved to disk'
+    Remember that you need to set a nil face-pair in your config for this to work, like so:
+    (setq telephone-line-lhs
+    	'( (nil . telephone-line-buffer-modified-segment) ) )"
+  )
+
+(defcustom telephone-line-buffer-unmodified-display-string "-"
+  "text to display when the buffer has not been changed since the last time the buffer was saved to disk"
+  :type '(string)
+  :group 'telephone-line)
+
+(telephone-line-defsegment telephone-line-buffer-modified-segment ()
+  (if (buffer-modified-p)
+      (telephone-line-raw (propertize telephone-line-buffer-modified-display-string 'face 'telephone-line-buffer-modified))
+    (telephone-line-raw (propertize telephone-line-buffer-unmodified-display-string 'face 'telephone-line-buffer-unmodified))
+    )
+  )
 
 (telephone-line-defsegment telephone-line-narrow-segment ()
   "%n")


### PR DESCRIPTION
I loved the buffer-modified-segment, and I

1.  wanted to use different strings for it, and I
2.  wanted the 'modified' string to show up in read.

This PR does that.

What can I do to help with this process?

telephone-line-buffer-modified-segment, now with customize-able
strings to display when the buffer is (un)modified.
Also supports customize-able faces for when the buffer
is (un)modified.
Note that the face will only display correctly when the lhs/rhs
is configured with a nil face pair.