### PR TITLE
New segments proposals

### DIFF
--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -92,6 +92,14 @@ Adapted from doom-modeline."
 (telephone-line-defsegment* telephone-line-minions-mode-segment ()
   (telephone-line-raw minions-mode-line-modes t))
 
+(telephone-line-defsegment* telephone-line-buffer-name-segment ()
+  (telephone-line-raw (buffer-name)))
+
+(telephone-line-defsegment* telephone-line-buffer-modified-segment ()
+    (if (buffer-modified-p)
+        (telephone-line-raw "!")
+      (telephone-line-raw "-")))
+
 (telephone-line-defsegment telephone-line-narrow-segment ()
   "%n")
 

--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -30,6 +30,23 @@
 (telephone-line-defsegment telephone-line-process-segment ()
   mode-line-process)
 
+(telephone-line-defsegment* telephone-line-vc-nobackend-segment ()
+  (if vc-mode
+      (replace-regexp-in-string ".*?[-:@!?]" "" (substring-no-properties vc-mode))
+    " - "))
+
+(telephone-line-defsegment* telephone-line-buffer-shortname-segment ()
+  ;; Avoids the padding in the regular "buffer only" segment
+  (buffer-name))
+
+(telephone-line-defsegment* telephone-line-position+region-segment ()
+  (let ((region-size (when (use-region-p)
+                       (format " (%sL:%sC)"
+                               (count-lines (region-beginning)
+                                            (region-end))
+                               (- (region-end) (region-beginning))))))
+    (list "%l:%c" region-size)))
+
 (telephone-line-defsegment* telephone-line-position-segment ()
   (telephone-line-raw
    (if (eq major-mode 'paradox-menu-mode)

--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -32,7 +32,7 @@
 
 (telephone-line-defsegment* telephone-line-vc-nobackend-segment ()
   (if vc-mode
-      (replace-regexp-in-string ".*?[-:@!?]" "" (substring-no-properties vc-mode))
+      (substring-no-properties vc-mode (+ 1 (string-match "[-:@!?]" vc-mode)))
     " - "))
 
 (telephone-line-defsegment* telephone-line-buffer-shortname-segment ()

--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -122,9 +122,10 @@ Adapted from doom-modeline."
   buffer-file-name)
 
 (telephone-line-defsegment* telephone-line-buffer-modified-segment ()
-    (if (buffer-modified-p)
-        (telephone-line-raw "!")
-      (telephone-line-raw "-")))
+  (cond
+   (buffer-read-only "·")
+   ((buffer-modified-p) "!")
+   (t "-")))
 
 (telephone-line-defsegment telephone-line-narrow-segment ()
   "%n")

--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -31,6 +31,7 @@
   mode-line-process)
 
 (telephone-line-defsegment* telephone-line-vc-nobackend-segment ()
+  "Like `telephone-line-vc-segment', but without the backend prefix, only the branch name."
   (if vc-mode
       (substring-no-properties vc-mode (+ 1 (string-match "[-:@!?]" vc-mode)))
     " - "))
@@ -40,6 +41,7 @@
   (buffer-name))
 
 (telephone-line-defsegment* telephone-line-position+region-segment ()
+  "Minimal position segment, combines line:column, and chars:lines in the region, if active."
   (let ((region-size (when (use-region-p)
                        (format " (%sL:%sC)"
                                (count-lines (region-beginning)
@@ -122,9 +124,11 @@ Adapted from doom-modeline."
   buffer-file-name)
 
 (telephone-line-defsegment* telephone-line-buffer-modified-segment ()
+  "Small, text only segment for the buffer state.
+Uses the standard modeline chars."
   (cond
-   (buffer-read-only "·")
-   ((buffer-modified-p) "!")
+   (buffer-read-only "%")
+   ((buffer-modified-p) "*")
    (t "-")))
 
 (telephone-line-defsegment telephone-line-narrow-segment ()

--- a/telephone-line-utils.el
+++ b/telephone-line-utils.el
@@ -220,7 +220,8 @@ Includes padding."
 (cl-defmethod telephone-line-separator-render-image ((obj telephone-line-separator) foreground background)
   "Find cached pbm of OBJ in FOREGROUND and BACKGROUND.
 If it doesn't exist, create and cache it."
-  (let ((hash-key (concat background "_" foreground)))
+  (let* ((height (telephone-line-separator-height obj))
+         (hash-key (format "%s_%s_%s" background foreground height)))
     ;; Return cached image if we have it.
     (or (gethash hash-key (oref obj image-cache))
         (puthash hash-key


### PR DESCRIPTION
- Plain buffer name: the standard buffer name has a minimum width that I didn't like. I doubt on this segment, I guess the regular buffer-name one could receive a parameter to indicate the padding.

- VC without back end: No point in seeing "Git" in all buffers :) I also removed the character indicators for modified, not added, etc. I think this could be renamed "vc-branch-only" to reflect the intent more accurately, but again, could be an argument in the existing vc segment.

- Position + region size: I really like having the position only, as I don't care about the size of the buffer, or the "bottom", "all", etc. indicators. I added on top of it the region size, I know other modeline packages have it, so it must be ok, but can't help thinking in a big enough region counting lines and chars can be too slow.