### PR TITLE
Add telephone-line-flymake-segment

### DIFF
--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -265,6 +265,10 @@ Configure the face group telephone-line-evil to change the colors per-mode."
           (seq-take tag 2)
         tag))))
 
+(telephone-line-defsegment telephone-line-flymake-segment ()
+  "Wraps `flymake-mode' mode-line information in a telephone-line segment."
+  (telephone-line-raw flymake--mode-line-format t))
+
 (telephone-line-defsegment telephone-line-flycheck-segment ()
   "Displays current checker state."
   (when (bound-and-true-p flycheck-mode)

--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -267,7 +267,8 @@ Configure the face group telephone-line-evil to change the colors per-mode."
 
 (telephone-line-defsegment telephone-line-flymake-segment ()
   "Wraps `flymake-mode' mode-line information in a telephone-line segment."
-  (telephone-line-raw flymake--mode-line-format t))
+  (when (bound-and-true-p flymake-mode)
+    (telephone-line-raw flymake--mode-line-format t)))
 
 (telephone-line-defsegment telephone-line-flycheck-segment ()
   "Displays current checker state."


### PR DESCRIPTION
Flymake provides a `flymake--mode-line-format` for the time being, so we can wrap it to provide a simple segment for Flymake