### PR TITLE
Adapt flymake-segment to upstream changes

### DIFF
--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -267,7 +267,10 @@ Configure the face group telephone-line-evil to change the colors per-mode."
 (telephone-line-defsegment telephone-line-flymake-segment ()
   "Wraps `flymake-mode' mode-line information in a telephone-line segment."
   (when (bound-and-true-p flymake-mode)
-    (telephone-line-raw flymake--mode-line-format t)))
+    (telephone-line-raw
+     (if (boundp flymake--mode-line-format) 
+         flymake--mode-line-format
+       flymake-mode-line-format) t)))
 
 (telephone-line-defsegment telephone-line-flycheck-segment ()
   "Displays current checker state."


### PR DESCRIPTION
Since last [december](https://git.savannah.gnu.org/cgit/emacs.git/commit/lisp/progmodes/flymake.el?id=2e6fbb05b6c17a1481fd6b73491cfa9c66c0c84f),
the name of the flymake mode line format variable changed.

Use a boundp check to use the correct variable.