### PR TITLE
Bump version to 0.5 for NonGNU ELPA

### DIFF
--- a/telephone-line-config.el
+++ b/telephone-line-config.el
@@ -1,6 +1,6 @@
 ;;; telephone-line-config.el --- Easy config for telephone-line
 
-;; Copyright (C) 2015-2017 Daniel Bordak
+;; Copyright (C) 2015-2022 Daniel Bordak
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -1,6 +1,6 @@
 ;;; telephone-line-segments.el --- Segments for Telephone Line -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015-2017 Daniel Bordak
+;; Copyright (C) 2015-2022 Daniel Bordak
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/telephone-line-separators.el
+++ b/telephone-line-separators.el
@@ -1,6 +1,6 @@
 ;;; telephone-line-separators.el --- Separators for Telephone Line
 
-;; Copyright (C) 2015-2017 Daniel Bordak
+;; Copyright (C) 2015-2022 Daniel Bordak
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/telephone-line-utils.el
+++ b/telephone-line-utils.el
@@ -1,6 +1,6 @@
 ;;; telephone-line-utils.el --- Functions for defining segparators and segments -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015-2017 Daniel Bordak
+;; Copyright (C) 2015-2022 Daniel Bordak
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/telephone-line.el
+++ b/telephone-line.el
@@ -4,7 +4,7 @@
 
 ;; Author: Daniel Bordak <dbordak@fastmail.fm>
 ;; URL: https://github.com/dbordak/telephone-line
-;; Version: 0.4
+;; Version: 0.5
 ;; Keywords: mode-line
 ;; Package-Requires: ((emacs "24.4") (cl-lib "0.5") (cl-generic "0.2") (seq "1.8"))
 

--- a/telephone-line.el
+++ b/telephone-line.el
@@ -1,6 +1,6 @@
 ;;; telephone-line.el --- Rewrite of Powerline -*- lexical-binding: t -*-
 
-;; Copyright (C) 2015-2017 Daniel Bordak
+;; Copyright (C) 2015-2022 Daniel Bordak
 
 ;; Author: Daniel Bordak <dbordak@fastmail.fm>
 ;; URL: https://github.com/dbordak/telephone-line


### PR DESCRIPTION
Hi!

I am investigating if we could add this package to [NonGNU ELPA](http://elpa.nongnu.org/) (see link), a new Emacs Lisp package archive that will be enabled by default in Emacs 28. This means that users of that version or later will be able to install this package without any configuration: they can just run `M-x list-packages` and install it out of the box. We hope that this will improve Emacs and help bring new users to this package and others.

The main difference between NonGNU ELPA and MELPA is that only stable versions of packages are released. A new release will be made automatically when you bump the ";; Version: NNN" commentary header in this repository, as I do in this commit. NonGNU ELPA does not look at any "git tag". In the future, you can bump the package version in that header (thereby releasing a new version) when you think it makes sense and at your convenience.

I also took this opportunity to update the copyright years for good measure.

The rules for accepting a package into NonGNU ELPA are here, for your reference:
https://git.savannah.gnu.org/cgit/emacs/nongnu.git/tree/README.org#n133

As far as I can tell, this package already follows the rules so there should be nothing more to do with regards to that.

Please let me know if you have any questions about NonGNU ELPA.

Thanks!