### PR TITLE
Add a segment for Project.el

### DIFF
--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -208,6 +208,26 @@ If it doesn't exist, create and cache it."
                                          (interactive)
                                          (projectile-switch-project))))))
 
+(defcustom telephone-line-project-custom-name nil
+  "A custom directory-local name for a project.el project."
+  :type 'string
+  :group 'telephone-line)
+
+(telephone-line-defsegment telephone-line-project-segment ()
+  "Displays the project name, according to project.el"
+  (if (project-current)
+      (propertize (if (stringp telephone-line-project-custom-name)
+          telephone-line-project-custom-name
+        (file-name-nondirectory
+         (directory-file-name
+          (project-root (project-current)))))
+                  'face 'telephone-line-projectile
+                  'display '(raise 0.0)
+                  'help-echo "Switch project"
+                  'mouse-face '(:box 1)
+                  'local-map (make-mode-line-mouse-map
+                              'mouse-1 #'project-switch-project))))
+
 (defun telephone-line--truncate-dir (dir)
   "Truncate DIR, respecting word boundaries."
   (if (string= dir "~")
@@ -268,7 +288,7 @@ Configure the face group telephone-line-evil to change the colors per-mode."
   "Wraps `flymake-mode' mode-line information in a telephone-line segment."
   (when (bound-and-true-p flymake-mode)
     (telephone-line-raw
-     (if (boundp flymake--mode-line-format) 
+     (if (boundp flymake--mode-line-format)
          flymake--mode-line-format
        flymake-mode-line-format) t)))
 


### PR DESCRIPTION
This pull requests adds a segment for a project.el project name. It also includes a custom variable for setting the project name inside your .dir-locals.el in case you want to customize the project name.

For example:

```elisp
;;; Directory Local Variables
;;; For more information see (info "(emacs) Directory Variables")

((nil . ((telephone-line-project-custom-name . "Telephone Line Rocks"))))
```
![Screenshot from 2022-03-07 10-23-46](https://user-images.githubusercontent.com/28788713/157094733-4a46a743-00fa-4dcd-9f3c-e084aa397604.png)
