### PR TITLE
Fix flymake mode segment

### DIFF
--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -267,10 +267,7 @@ Configure the face group telephone-line-evil to change the colors per-mode."
 (telephone-line-defsegment telephone-line-flymake-segment ()
   "Wraps `flymake-mode' mode-line information in a telephone-line segment."
   (when (bound-and-true-p flymake-mode)
-    (telephone-line-raw
-     (if (boundp flymake--mode-line-format) 
-         flymake--mode-line-format
-       flymake-mode-line-format) t)))
+    (telephone-line-raw flymake-mode-line-format t)))
 
 (telephone-line-defsegment telephone-line-flycheck-segment ()
   "Displays current checker state."


### PR DESCRIPTION
The flymake mode segment is broken for me:

```
(fn FACE)"]) telephone-line-cubed-hollow-right 'nil)) signaled (void-variable flymake--mode-line-format)
Error during redisplay: (eval (telephone-line-add-subseparators '(#[257 "\303\304\300!\205
```

I've corrected it by removing the check to return `flymake--mode-line-format`