### PR TITLE
Fix predicate of xah-fly-keys segment

### DIFF
--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -325,8 +325,9 @@ Configure the face group telephone-line-evil to change the colors per-mode."
                               'mouse-1 #'flycheck-list-errors)))))
 
 (telephone-line-defsegment* telephone-line-xah-fly-keys-segment ()
-  (when (boundp xah-fly-insert-state-q)
-    (let ((tag (if xah-fly-insert-state-q
+  "Display the current mode for Xah Fly Keys."
+  (when (boundp xah-fly-insert-state-p)
+    (let ((tag (if xah-fly-insert-state-p
                    "INSERT" "COMMAND")))
       (if telephone-line-evil-use-short-tag
           (seq-take tag 1)

--- a/telephone-line.el
+++ b/telephone-line.el
@@ -221,12 +221,12 @@ Secondary separators do not incur a background color change."
         ((not ryo-modal-mode) 'telephone-line-evil-insert)
         (t 'telephone-line-evil-normal)))
 
-(defvar xah-fly-insert-state-q) ; silence byte-compiler
+(defvar xah-fly-insert-state-p) ; silence byte-compiler
 (defun telephone-line-modal-face (active)
   "Return an appropriate face for the current mode, given whether the frame is ACTIVE."
   (cond ((not active) 'mode-line-inactive)
         ((bound-and-true-p xah-fly-keys)
-         (if xah-fly-insert-state-q
+         (if xah-fly-insert-state-p
              'telephone-line-evil-insert
            'telephone-line-evil-normal))
         ((not (bound-and-true-p evil-mode)) 'mode-line)


### PR DESCRIPTION
The variable name changed approx. 1 year ago, in
https://github.com/xahlee/xah-fly-keys/commit/c6a7367afa0dbdb734319268f4e0bb708f4fec11