### PR TITLE
Fix: quote flymake--mode-line-format symbol boundp check

### DIFF
--- a/telephone-line-segments.el
+++ b/telephone-line-segments.el
@@ -288,8 +288,7 @@ Configure the face group telephone-line-evil to change the colors per-mode."
   "Wraps `flymake-mode' mode-line information in a telephone-line segment."
   (when (bound-and-true-p flymake-mode)
     (telephone-line-raw
-     (if (boundp flymake--mode-line-format)
-         flymake--mode-line-format
+     (if (boundp 'flymake--mode-line-format) flymake--mode-line-format
        flymake-mode-line-format) t)))
 
 (telephone-line-defsegment telephone-line-flycheck-segment ()


### PR DESCRIPTION
It seems like the symbol flymake--mode-line-format is no longer found in the flymake package's code, so this was raising a void symbol error. Quoting it should keep it backwards compatible for whatever behavior this was using previously, and prevent the error from making it so the flymake-mode-line-format variable was not being processed.